### PR TITLE
Update to new Postman url

### DIFF
--- a/resources/cayman/index.md
+++ b/resources/cayman/index.md
@@ -28,7 +28,7 @@ The HTML format can be used to add to websites, rendering perfectly in the brows
 This API can be used with either tools:
 - [curl](https://curl.haxx.se/)
 - [wget](https://www.gnu.org/software/wget/)
-- [Postman](https://www.getpostman.com/)
+- [Postman](https://www.postman.com/)
 - Web Browsers etc
 
 # Usage


### PR DESCRIPTION
The Postman url changed from www.getpostman.com to www.postman.com.
Please accept my PR, it will really help us out. Thank you 🙌